### PR TITLE
Catch and optionally retry failed node get calls

### DIFF
--- a/cicoclient/cli.py
+++ b/cicoclient/cli.py
@@ -89,6 +89,20 @@ class NodeGet(Lister):
             default=1,
             help='Requested amount of servers. Defaults to 1.'
         )
+        parser.add_argument(
+            '--try-count',
+            metavar='<count>',
+            type=int,
+            default=1,
+            help='Number of attempts to make. Defaults to 1.'
+        )
+        parser.add_argument(
+            '--try-wait',
+            metavar='<seconds>',
+            type=int,
+            default=30,
+            help='Wait between subsequent retries. Defaults to 30 (seconds).'
+        )
         return parser
 
     @utils.log_method(log)
@@ -100,7 +114,9 @@ class NodeGet(Lister):
 
         hosts, ssid = api.node_get(arch=parsed_args.arch,
                                    ver=parsed_args.release,
-                                   count=parsed_args.count)
+                                   count=parsed_args.count,
+                                   try_count=parsed_args.try_count,
+                                   try_wait=parsed_args.try_wait)
         message = "SSID for these servers: %s\n" % ssid
         sys.stdout.write(message)
 

--- a/cicoclient/exceptions.py
+++ b/cicoclient/exceptions.py
@@ -23,6 +23,14 @@ class ApiKeyRequired(Exception):
         return "The requested operation requires an API key."
 
 
+class NoInventory(Exception):
+    """
+    When requesting nodes from Duffy and no inventory is available
+    """
+    def __str__(self):
+        return "The requested operation failed as no inventory is available."
+
+
 class SsidRequired(Exception):
     """
     When running a command that requires an api key and the api key is not

--- a/cicoclient/wrapper.py
+++ b/cicoclient/wrapper.py
@@ -133,6 +133,9 @@ class CicoWrapper(client.CicoClient):
 
         resp, body = self.get('Node/get?%s' % args)
 
+        if not body:
+            raise exceptions.NoInventory
+
         # Get the hosts that were requested.
         # Note: We have to iterate over full inventory instead of just the
         # hosts we got back from the response because the reply contains the


### PR DESCRIPTION
Two parts - the first raises a nicer exception when the API returns an empty body from the node get call to indicate that it's out of nodes, and the second adds retry functionality.  The latter would be very useful in our SCLo SIG tests, as we're frequently running many jobs at once and I'd like to be able to let them run and wait.