### PR TITLE
rename ansible return from results to cico_results

### DIFF
--- a/cicoclient/ansible/cico.py
+++ b/cicoclient/ansible/cico.py
@@ -203,24 +203,23 @@ def main():
                 'hosts': hosts,
                 'ssid': new_ssid
             }
-            module.exit_json(changed=True, results=data)
 
-        if action == 'done':
+        elif action == 'done':
             hosts = api.node_done(ssid=ssid)
             data = {
                 'message': 'Released servers successfully',
                 'hosts': hosts
             }
-            module.exit_json(changed=True, results=data)
 
-        if action == 'list':
+        elif action == 'list':
             hosts = api.inventory(ssid=ssid)
 
             data = {
                 'message': 'Listed servers successfully',
                 'hosts': hosts
             }
-            module.exit_json(changed=True, results=data)
+
+        module.exit_json(changed=True, cico_results=data)
 
     except Exception as e:
         module.fail_json(msg=e.message)


### PR DESCRIPTION
`results` is a reserved keyword since Ansible 2.8
https://github.com/ansible/ansible/commit/3637ce45385e92a3d96095464d752c43a6fdf775

If a module returns `results`, the variable gets renamed to
`ansible_module_results`, which makes using the data in playbooks
cumbersome. Rename the var to `cico_results` to it's consistent on all
Ansible versions.