### PR TITLE
build python3 on el8

### DIFF
--- a/python-cicoclient.spec
+++ b/python-cicoclient.spec
@@ -1,5 +1,5 @@
 Name:             python-cicoclient
-Version:          0.4.4
+Version:          0.4.7
 Release:          1%{?dist}
 Summary:          Client interfaces to admin.ci.centos.org
 
@@ -81,6 +81,15 @@ rm -rf html/.doctrees html/.buildinfo
 %doc html
 
 %changelog
+* Fri Oct 22 2021 Evgeni Golov - 0.4.7-1
+- Update to 0.4.7
+
+* Tue Oct 19 2021 arrfab@centos.org - 0.4.6-1
+- Bumped to 0.4.6 for 9-stream support
+
+* Tue Oct 29 2019 brian@bstinson.com - 0.4.5-1
+- Add CentOS 8 and 8-Stream
+
 * Thu Nov 29 2018 brian@bstinson.com - 0.4.4-1
 - Fixup the default flavor for ansible
 

--- a/python-cicoclient.spec
+++ b/python-cicoclient.spec
@@ -15,7 +15,6 @@ BuildRequires:    python-cliff
 BuildRequires:    python-pbr
 BuildRequires:    python-requests
 BuildRequires:    python-setuptools
-BuildRequires:    python-simplejson
 BuildRequires:    python-six
 
 # Work around an old version of python-sphinx_rtd_theme in CBS
@@ -24,7 +23,6 @@ BuildRequires:    fontawesome-fonts-web
 Requires:         python-cliff >= 1.14.0
 Requires:         python-pbr >= 1.6
 Requires:         python-requests >= 2.5.2
-Requires:         python-simplejson
 Requires:         python-six >= 1.9.0
 
 %description

--- a/python-cicoclient.spec
+++ b/python-cicoclient.spec
@@ -1,3 +1,11 @@
+%if 0%{?rhel} && 0%{?rhel} < 8
+%bcond_without python2
+%bcond_with python3
+%else
+%bcond_with python2
+%bcond_without python3
+%endif
+
 Name:             python-cicoclient
 Version:          0.4.7
 Release:          1%{?dist}
@@ -10,17 +18,36 @@ Source0:          https://pypi.io/packages/source/p/%{name}/%{name}-%{version}.t
 BuildArch:        noarch
 
 BuildRequires:    git
+
+%if %{with python2}
 BuildRequires:    python2-devel
 BuildRequires:    python-cliff
 BuildRequires:    python-pbr
 BuildRequires:    python-requests
 BuildRequires:    python-setuptools
 BuildRequires:    python-six
+%endif
+%if %{with python3}
+BuildRequires:    python3-devel
+#BuildRequires:    python3-cliff
+BuildRequires:    python3-pbr
+BuildRequires:    python3-requests
+BuildRequires:    python3-setuptools
+BuildRequires:    python3-six
+%endif
 
+%if %{with python2}
 Requires:         python-cliff >= 1.14.0
 Requires:         python-pbr >= 1.6
 Requires:         python-requests >= 2.5.2
 Requires:         python-six >= 1.9.0
+%endif
+%if %{with python3}
+Requires:         python3-cliff >= 1.14.0
+Requires:         python3-pbr >= 1.6
+Requires:         python3-requests >= 2.5.2
+Requires:         python3-six >= 1.9.0
+%endif
 
 %description
 python-cicoclient is a client, library, and a CLI interface that can be used to
@@ -29,8 +56,14 @@ communicate with the ci.centos.org infrastructure provisioning system: Duffy.
 %package doc
 Summary:          Documentation for python-cicoclient
 
+%if %{with python2}
 BuildRequires:    python-sphinx
 BuildRequires:    python-sphinx_rtd_theme
+%endif
+%if %{with python3}
+BuildRequires:    python3-sphinx
+BuildRequires:    python3-sphinx_rtd_theme
+%endif
 
 Requires:         %{name} = %{version}-%{release}
 
@@ -47,10 +80,20 @@ This package contains auto-generated documentation.
 rm -f requirements.txt test-requirements.txt
 
 %build
+%if %{with python2}
 %{__python2} setup.py build
+%endif
+%if %{with python3}
+%py3_build
+%endif
 
 %install
+%if %{with python2}
 %{__python2} setup.py install --skip-build --root %{buildroot}
+%endif
+%if %{with python3}
+%py3_install
+%endif
 
 export PYTHONPATH="$( pwd ):$PYTHONPATH"
 sphinx-build -b html docs html
@@ -65,8 +108,14 @@ rm -rf html/.doctrees html/.buildinfo
 %license LICENSE
 %doc README.rst
 %{_bindir}/cico
+%if %{with python2}
 %{python2_sitelib}/cicoclient
 %{python2_sitelib}/*.egg-info
+%endif
+%if %{with python3}
+%{python3_sitelib}/cicoclient
+%{python3_sitelib}/*.egg-info
+%endif
 %{_mandir}/man1/cico.1*
 
 %files doc

--- a/python-cicoclient.spec
+++ b/python-cicoclient.spec
@@ -17,9 +17,6 @@ BuildRequires:    python-requests
 BuildRequires:    python-setuptools
 BuildRequires:    python-six
 
-# Work around an old version of python-sphinx_rtd_theme in CBS
-BuildRequires:    fontawesome-fonts-web
-
 Requires:         python-cliff >= 1.14.0
 Requires:         python-pbr >= 1.6
 Requires:         python-requests >= 2.5.2
@@ -34,8 +31,6 @@ Summary:          Documentation for python-cicoclient
 
 BuildRequires:    python-sphinx
 BuildRequires:    python-sphinx_rtd_theme
-# python-sphinx_rtd_theme missing dependency https://bugzilla.redhat.com/show_bug.cgi?id=1282297
-BuildRequires:    fontawesome-fonts-web
 
 Requires:         %{name} = %{version}-%{release}
 


### PR DESCRIPTION
this is a hack, and should not be used as-is, but good enough to start a discussion ;)
contains #30 as that has some good cleanup

I can currently build the pkg on EPEL8, but to run it needs python3-cliff from the EL8-OpenStack repos :woman_shrugging: (in my tests I used `centos-release-openstack-victoria`)