### PR TITLE
remove unsupported releases from the ansible module

### DIFF
--- a/cicoclient/ansible/cico.py
+++ b/cicoclient/ansible/cico.py
@@ -38,7 +38,7 @@ options:
     release:
         description:
             - CentOS release
-        choices: [5, 6, 7, 8, 8-stream, 9-stream]
+        choices: [7, 8-stream, 9-stream]
         default: 7
     flavor:
         description:
@@ -157,7 +157,7 @@ def main():
                                            'lram.tiny', 'lram.small',
                                            'xram.tiny', 'xram.small',
                                            'xram.medium', 'xram.large']),
-        release=dict(default='7', choices=['5', '6', '7', '8', '8-stream',
+        release=dict(default='7', choices=['7', '8-stream',
                                            '9-stream']),
         count=dict(default=1, type='int'),
         retry_count=dict(default=1, type='int'),


### PR DESCRIPTION
el5, el6 and el8 (non-stream) are unsupported