### PR TITLE
Force ssids to be strings in comparison

### DIFF
--- a/cicoclient/wrapper.py
+++ b/cicoclient/wrapper.py
@@ -109,7 +109,7 @@ class CicoWrapper(client.CicoClient):
         """
         matching_hosts = {}
         for host in inventory:
-            if inventory[host]['comment'] == ssid:
+            if str(inventory[host]['comment']) == ssid:
                 matching_hosts[host] = inventory[host]
 
         return matching_hosts
@@ -202,7 +202,7 @@ class CicoWrapper(client.CicoClient):
         # the specified ssid to return them.
         requested_hosts = dict()
         for host in self.self_inventory:
-            if ssid == self.self_inventory[host]['comment']:
+            if ssid == str(self.self_inventory[host]['comment']):
                 requested_hosts[host] = self.full_inventory[host]
 
         args = "key={key}&ssid={ssid}".format(key=self.api_key, ssid=ssid)


### PR DESCRIPTION
In the new Duffy the cico API returns SSIDs as integers rather than strings. This causes the comparison to fail.

```
$ cico inventory
+---------+------------+-------------+---------+------------+---------------+---------+--------+------+----------------+--------------+---------------------------------------+--------------+--------+
| host_id | hostname   | ip_address  | chassis | used_count | current_state | comment | distro | rel  | centos_version | architecture | node_pool                             | console_port | flavor |
+---------+------------+-------------+---------+------------+---------------+---------+--------+------+----------------+--------------+---------------------------------------+--------------+--------+
|     306 | n53.crusty | 172.19.2.53 | None    |          0 | deployed      |     504 | None   | None | None           | None         | metal-seamicro-large-centos-8s-x86_64 | None         | None   |
+---------+------------+-------------+---------+------------+---------------+---------+--------+------+----------------+--------------+---------------------------------------+--------------+--------+
$ cico inventory --ssid 504

$ cico node done 504

$ cico inventory
```

This shouldn't be needed. Trying to work to get the legacy API fixed instead, but having this PR helps to highlight the problem.